### PR TITLE
Clean up the find+replace lists before rendering an email template

### DIFF
--- a/admin/class-wcemails-instance.php
+++ b/admin/class-wcemails-instance.php
@@ -60,6 +60,10 @@ if ( ! class_exists( 'WCEmails_Instance' ) && class_exists( 'WC_Email' ) ) {
 		 * @return void
 		 */
 		function trigger( $order_id ) {
+			// clean up possible leftover from previous invocations (e.g. in case of bulk updates&sends)
+			$this->find = array();
+			$this->replace = array();
+			
 			// checkbox of send to customer is checked or not.
 			$send_to_customer = ('on' == $this->send_customer);
 


### PR DESCRIPTION
The problem this solves is the following: when the user bulk edits multiple orders, it can trigger multiple email sends. Without this change, the subsequent emails would inherit the contents of the find&replace lists used for the previous emails. (What I experienced was that the value of `woocommerce_email_order_meta` was the same in all the sent emails, even though it was different for each order.)
This PR fixes the issue by resetting the find&replace lists for each triggering. 